### PR TITLE
Add env vars for MQTT config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Install ngrok
+RUN apt-get update && apt-get install -y wget unzip \
+    && wget -q -O /tmp/ngrok.zip https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip \
+    && unzip -d /usr/local/bin /tmp/ngrok.zip \
+    && rm /tmp/ngrok.zip \
+    && apt-get purge -y wget unzip \
+    && apt-get autoremove -y && apt-get clean
+
+# Copy application files
+COPY mqtt_mcp_server.py ./
+COPY traffic-policy.yml ./
+COPY start.sh ./
+
+# Default environment variables
+ENV TRANSPORT=sse \
+    FASTMCP_HOST=0.0.0.0 \
+    FASTMCP_PORT=8000 \
+    MQTT_BROKER_ADDRESS=localhost \
+    MQTT_PORT=1883 \
+    MQTT_CLIENT_ID=mcp-mqtt-client \
+    MQTT_USERNAME= \
+    MQTT_PASSWORD=
+
+EXPOSE 8000
+
+CMD ["./start.sh"]

--- a/README.md
+++ b/README.md
@@ -177,6 +177,33 @@ python mqtt_mcp_server.py \
 | **Remote AI agents** | `python mqtt_mcp_server.py --transport streamable-http --host 0.0.0.0` | Supports authentication, scalable |
 | **Legacy systems** | `python mqtt_mcp_server.py --transport sse` | Only if you're already using SSE |
 
+## 🐳 Docker with Ngrok
+
+Run the server inside Docker and automatically expose it with an ngrok tunnel.
+
+### Build
+```bash
+docker build -t mqtt-mcp-ngrok .
+```
+
+### Run
+```bash
+docker run -d \
+  -p 8000:8000 \
+  -e NGROK_AUTHTOKEN=<YOUR_TOKEN> \
+  -e TRANSPORT=sse \
+  -e FASTMCP_PORT=8000 \
+  -e MQTT_BROKER_ADDRESS=mqtt.example.com \
+  -e MQTT_PORT=8883 \
+  -e MQTT_CLIENT_ID=my-client \
+  -e MQTT_USERNAME=prod_user \
+  -e MQTT_PASSWORD=secret123 \
+  mqtt-mcp-ngrok
+```
+The container exposes the MCP server via ngrok. Pass environment variables to
+configure the MQTT broker and server transport. Check the container logs to
+discover the public URL.
+
 ## 📚 Learn More
 
 - [Model Context Protocol Specification](https://spec.modelcontextprotocol.io/)

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -e
+
+# Configure ngrok if token provided
+if [ -n "$NGROK_AUTHTOKEN" ]; then
+    ngrok config add-authtoken "$NGROK_AUTHTOKEN"
+fi
+
+# Default environment variables for MCP server
+# These mirror the CLI arguments in mqtt_mcp_server.py
+: "${TRANSPORT:=sse}"
+: "${FASTMCP_PORT:=8000}"
+: "${MQTT_BROKER_ADDRESS:=localhost}"
+: "${MQTT_PORT:=1883}"
+: "${MQTT_CLIENT_ID:=mcp-mqtt-client}"
+# MQTT_USERNAME and MQTT_PASSWORD are optional
+
+# Start ngrok tunnel in background
+# Exposes the configured FASTMCP_PORT over HTTP
+ngrok http "$FASTMCP_PORT" --log=stdout &
+
+# Start MQTT MCP server with env-configurable CLI arguments
+exec python mqtt_mcp_server.py \
+    --transport "$TRANSPORT" \
+    --broker "$MQTT_BROKER_ADDRESS" \
+    --port "$MQTT_PORT" \
+    --client-id "$MQTT_CLIENT_ID" \
+    ${MQTT_USERNAME:+--username "$MQTT_USERNAME"} \
+    ${MQTT_PASSWORD:+--password "$MQTT_PASSWORD"}


### PR DESCRIPTION
## Summary
- add env defaults for MQTT options in Dockerfile
- expand `start.sh` to use env vars for all CLI arguments
- document MQTT-related environment variables for Docker run

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844ce4b03148324b919ecdca48c6075